### PR TITLE
[ new ] parsing molecular formulae

### DIFF
--- a/chem.ipkg
+++ b/chem.ipkg
@@ -27,6 +27,7 @@ modules = Chem
         , Text.Molfile.Writer
 
         , Text.Lex.Element
+        , Text.Lex.Formula
 
         , Text.Smiles
         , Text.Smiles.Lexer

--- a/pack.toml
+++ b/pack.toml
@@ -24,14 +24,20 @@ type   = "local"
 path   = "profile"
 ipkg   = "profile.ipkg"
 
-[custom.all.array]
+[custom.all.quantifiers-extra]
 type   = "git"
-url    = "https://github.com/stefan-hoeck/idris2-array"
+url    = "https://github.com/stefan-hoeck/idris2-quantifiers-extra"
 commit = "latest:main"
-ipkg   = "array.ipkg"
+ipkg   = "quantifiers-extra.ipkg"
 
-[custom.all.indexed-graph]
-type   = "git"
-url    = "https://github.com/stefan-hoeck/idris2-indexed-graph"
-commit = "latest:main"
-ipkg   = "indexed-graph.ipkg"
+# [custom.all.array]
+# type   = "git"
+# url    = "https://github.com/stefan-hoeck/idris2-array"
+# commit = "latest:main"
+# ipkg   = "array.ipkg"
+#
+# [custom.all.indexed-graph]
+# type   = "git"
+# url    = "https://github.com/stefan-hoeck/idris2-indexed-graph"
+# commit = "latest:main"
+# ipkg   = "indexed-graph.ipkg"

--- a/src/Chem/Formula.idr
+++ b/src/Chem/Formula.idr
@@ -199,8 +199,9 @@ Monoid Formula where
 
 ||| Creates a molecular formula with the given element and count.
 export %inline
-singleton : Elem -> (n : Nat) -> (0 prf : IsSucc n) => Formula
-singleton e n = F [(e,n)]
+singleton : Elem -> (n : Nat) -> Formula
+singleton e 0     = F []
+singleton e (S n) = F [(e,S n)]
 
 ||| True, if the first `Formula` contains at least the atoms listed
 ||| in the second formula, that is, all elements in the second formula

--- a/src/Text/Lex/Formula.idr
+++ b/src/Text/Lex/Formula.idr
@@ -1,0 +1,57 @@
+module Text.Lex.Formula
+
+import Chem
+import Chem.Formula
+import Data.List.Quantifiers.Extra
+import Derive.Prelude
+import Text.Bounds
+import Text.FC
+import Text.Lex.Element
+import Text.Lex.Manual
+
+%language ElabReflection
+%default total
+
+public export
+record FormulaErr where
+  constructor FE
+  formula : String
+  context : FileContext
+  error   : ParseError Void Void
+
+%runElab derive "FormulaErr" [Eq,Show]
+
+export
+Interpolation FormulaErr where
+  interpolate (FE s c e) = printParseError s c e
+
+lexNat : Elem -> SafeTok Formula
+lexNat e []        = Succ (singleton e 1) []
+lexNat e (x :: xs) =
+  if isDigit x
+     then singleton e <$> dec1 (digit x) xs
+     else Succ (singleton e 1) (x::xs)
+
+lexPair : StrictTok e Formula
+lexPair cs = case lexElement {orig} cs of
+  Succ val xs => lexNat val xs
+  Fail x y z  => Fail x y z
+
+export
+readFormula : Has FormulaErr es => String -> ChemRes es Formula
+readFormula s = go begin neutral (unpack s) suffixAcc
+  where
+    go :
+         Position
+      -> Formula
+      -> (ts : List Char)
+      -> (0 acc : SuffixAcc ts)
+      -> ChemRes es Formula
+    go p1 f [] _      = Right f
+    go p1 f cs (SA r) = case lexPair cs of
+      Succ v xs2 @{p}     =>
+        let p2 := endPos p1 p
+         in go p2 (f <+> v) xs2 r
+      Fail x e r =>
+        let B v bs := boundedErr p1 x e r
+         in Left . inject $ FE s (FC Virtual bs) v

--- a/test/src/Test/Chem/AtomType.idr
+++ b/test/src/Test/Chem/AtomType.idr
@@ -19,11 +19,6 @@ import Hedgehog
   * return `[]` if any of the above steps fails
 -}
 
--- Only temporary. Will be in `Data.List.Quantifiers.Extra`
-All (Show . f) ts => Show (Any f ts) where
-  showPrec @{_ :: _} p (Here v)  = showCon p "Here" (showArg v)
-  showPrec @{_ :: _} p (There v) = showCon p "There" (showArg v)
-
 calcAtomTypes : String -> ChemRes [HErr, ATErr, SmilesParseErr] (List AtomType)
 calcAtomTypes str = do
   g1     <- parse str

--- a/test/src/Test/Chem/Formula.idr
+++ b/test/src/Test/Chem/Formula.idr
@@ -1,0 +1,15 @@
+module Test.Chem.Formula
+
+import Chem
+import Chem.Formula
+import Test.Chem.Element
+
+import Hedgehog
+
+%default total
+
+export
+formula : Gen Formula
+formula =
+  foldMap (uncurry singleton) <$>
+  list (linear 0 20) [| MkPair element (nat $ linear 0 20) |]

--- a/test/src/Test/Main.idr
+++ b/test/src/Test/Main.idr
@@ -5,6 +5,7 @@ import Test.Data.Graph
 import Test.Chem.Element
 import Test.Chem.AtomType
 import Test.Text.Lex.Element
+import Test.Text.Lex.Formula
 import Test.Text.Molfile
 import Test.Text.Smiles.Lexer
 import Test.Text.Smiles.Parser
@@ -15,5 +16,6 @@ main = test [ Lex.Element.props
             , Smiles.Lexer.props
             , Smiles.Parser.props
             , Molfile.props
+            , Formula.props
             , AtomType.props
             ]

--- a/test/src/Test/Text/Lex/Formula.idr
+++ b/test/src/Test/Text/Lex/Formula.idr
@@ -1,0 +1,23 @@
+module Test.Text.Lex.Formula
+
+import Chem
+import Chem.Formula
+import Data.List.Quantifiers.Extra
+import Test.Chem.Formula
+import Text.Lex.Formula
+
+import Hedgehog
+
+%default total
+
+prop_roundTrip : Property
+prop_roundTrip = property $ do
+  f <- forAll formula
+  Right f === readFormula {es = [FormulaErr]} "\{f}"
+
+export
+props : Group
+props = MkGroup "Text.Lex.Formula"
+  [ ("prop_roundTrip", prop_roundTrip)
+  ]
+

--- a/test/src/Test/Text/Smiles/Parser.idr
+++ b/test/src/Test/Text/Smiles/Parser.idr
@@ -6,11 +6,6 @@ import Test.Text.Smiles.Generators
 
 %default total
 
--- TODO: This must go to quantifiers-extra
-All (Show . f) ts => Show (Any f ts) where
-  showPrec @{_ :: _} p (Here v)  = showCon p "Here" (showArg v)
-  showPrec @{_ :: _} p (There v) = showCon p "There" (showArg v)
-
 parse' : String -> ChemRes [SmilesParseErr] Mol
 parse' s = parse s
 


### PR DESCRIPTION
This adds a basic parser for molecular formulae. It does not yet support specific isotopes (our `Formula` type does not support those either).

Heads up: `Show` for `Data.List.Quantifiers.Any` has finally been added to quantifiers-extra, so this currently requires `pack fetch` before it compiles.