### PR TITLE
[ new, breaking ] writing MolFile

### DIFF
--- a/src/Text/Molfile/Reader.idr
+++ b/src/Text/Molfile/Reader.idr
@@ -195,7 +195,7 @@ readMol' (h1::h2::h3::cs::t) = do
   comment <- lineTok 2 molLine h3
   counts  <- lineTok 3 counts cs
   g       <- atoms [] counts.atoms counts.bonds 4 t
-  pure $ MkMolFile name info comment counts.atoms g
+  pure $ MkMolFile name info comment (G counts.atoms g)
 readMol' ls = Left (B (Custom EHeader) $ BS begin (P (length ls) 0))
 
 export %inline

--- a/src/Text/Molfile/Types.idr
+++ b/src/Text/Molfile/Types.idr
@@ -383,7 +383,6 @@ record MolFile where
   name    : MolLine
   info    : MolLine
   comment : MolLine
-  order   : Nat
-  graph   : IGraph order Bond Atom
+  graph   : Graph Bond Atom
 
-%runElab derive "MolFile" [Show]
+%runElab derive "MolFile" [Show,Eq]

--- a/src/Text/Molfile/Writer.idr
+++ b/src/Text/Molfile/Writer.idr
@@ -42,3 +42,12 @@ bond (E x y $ MkBond True t s r) =
  fastConcat [ fill 3 x, fill 3 y, fill 3 t, fill 3 s, fill 6 r]
 bond (E x y $ MkBond False t s r) =
  fastConcat [ fill 3 y, fill 3 x, fill 3 t, fill 3 s, fill 6 r]
+
+export
+writeMol : MolFile -> String
+writeMol (MkMolFile n i c $ G o g) =
+  let es := map bond (edges g)
+      as := foldr (\a,ls => atom a.label :: ls) es g.graph
+      cs := MkCounts o (length es) NonChiral V2000
+   in fastUnlines $
+      n.value :: i.value :: c.value :: counts cs :: as ++ ["M  END"]


### PR DESCRIPTION
Adds support for writing .mol files. This is a breaking change since the internal representation of `MolFile` has been changed slightly. I'll update the chemdoodle project accordingly, but a rebase will be required afterwards.