### PR TITLE
[ refactor ] generalize writeMol

### DIFF
--- a/src/Text/Molfile/Types.idr
+++ b/src/Text/Molfile/Types.idr
@@ -226,6 +226,11 @@ Interpolation Coordinate where
 namespace Coordinate
   %runElab derive "Coordinate" [Show,Eq,Ord,RefinedInteger]
 
+||| Convenience alias for `Vect 3 Coordinates`
+public export
+0 Coordinates : Type
+Coordinates = Vect 3 Coordinate
+
 ||| Regular atom loaded from a .mol file.
 |||
 ||| Note: .mol files support additional atom symbols
@@ -233,7 +238,7 @@ namespace Coordinate
 ||| this is the type to use.
 public export
 0 MolAtom : Type
-MolAtom = Atom Isotope Charge (Vect 3 Coordinate) Radical () () () ()
+MolAtom = Atom Isotope Charge Coordinates Radical () () () ()
 
 public export
 Cast Elem MolAtom where

--- a/src/Text/Molfile/Writer.idr
+++ b/src/Text/Molfile/Writer.idr
@@ -33,8 +33,8 @@ coords [x,y,z] = fastConcat [fill 10 x, fill 10 y, fill 10 z]
 ||| General format:
 |||   xxxxx.xxxxyyyyy.yyyyzzzzz.zzzz aaaddcccssshhhbbbvvvHHHrrriiimmmnnneee
 export
-atom : MolAtom -> String
-atom (MkAtom a c pos _ () () () ()) =
+atom : Atom Isotope Charge Coordinates Radical h t c l -> String
+atom (MkAtom a c pos _ _ _ _ _) =
   fastConcat [ coords pos, fill @{IP_ISO} 4 a, fill 5 c]
 
 ||| General format:
@@ -47,10 +47,17 @@ bond (E x y $ MkBond False t s) =
  fastConcat [ fill 3 y, fill 3 x, fill 3 t, fill 3 s]
 
 export
-writeMol : Molfile -> String
-writeMol (MkMolfile n i c $ G o g) =
+writeMol :
+     (name, info, comment : MolLine)
+  -> Graph MolBond (Atom Isotope Charge Coordinates Radical h t c l)
+  -> String
+writeMol n i c (G o g) =
   let es := map bond (edges g)
       as := foldr (\a,ls => atom a.label :: ls) es g.graph
       cs := MkCounts o (length es) NonChiral V2000
    in fastUnlines $
       n.value :: i.value :: c.value :: counts cs :: as ++ ["M  END"]
+
+export %inline
+writeMolfile : Molfile -> String
+writeMolfile (MkMolfile n i c g) = writeMol n i c g

--- a/test/src/Test/Text/Molfile.idr
+++ b/test/src/Test/Text/Molfile.idr
@@ -34,7 +34,7 @@ propRead s = property1 $ case readMol {es = [MolParseErr]} Virtual s of
 propReadRoundTrip : Property
 propReadRoundTrip = property $ do
   m <- forAll molFile
-  Right m === readMol {es = [MolParseErr]} Virtual (writeMol m)
+  Right m === readMol {es = [MolParseErr]} Virtual (writeMolfile m)
 
 export
 props : Group


### PR DESCRIPTION
While reading a .mol-file returns a specific type of graph, we can be more general when writing a .mol-file.