### PR TITLE
[ refactor ] linear mol-file parser

### DIFF
--- a/chem-generators/src/Test/Text/Molfile/Generators.idr
+++ b/chem-generators/src/Test/Text/Molfile/Generators.idr
@@ -75,6 +75,10 @@ atom : Gen MolAtom
 atom = [| MkAtom isotope charge coords radical u u u u |]
 
 export
+simpleAtom : Gen MolAtom
+simpleAtom = [| MkAtom (map cast elem) (pure 0) coords (pure NoRadical) u u u u |]
+
+export
 bondType : Gen BondType
 bondType = element [Single,Dbl,Triple]
 

--- a/test/src/Test/Text/Molfile.idr
+++ b/test/src/Test/Text/Molfile.idr
@@ -40,7 +40,7 @@ export
 props : Group
 props = MkGroup "Molfile Properties"
   [ ("prop_count", rw counts counts counts)
-  , ("prop_atom",  rw atom atom atom)
+  , ("prop_atom",  rw simpleAtom atom atom)
   , ("prop_bond",  rw bondEdge bond bond)
   , ("prop_sg1",   propRead sg1)
   ]


### PR DESCRIPTION
Instead of building up a vector during .mol-file parsing, which we then have to convert to a molgraph and update in (at least) linear time when applying the properties block, we can just as well use a mutable linear array. This is not yet done, so it's not yet clear if it will work out as intended, but it looks promising.