### PR TITLE
[ compat ] marvin does not understand v2000

### DIFF
--- a/src/Text/Molfile/Types.idr
+++ b/src/Text/Molfile/Types.idr
@@ -55,8 +55,8 @@ data MolVersion = V2000 | V3000
 
 export %inline
 Interpolation MolVersion where
-  interpolate V2000 = "v2000"
-  interpolate V3000 = "v3000"
+  interpolate V2000 = "V2000"
+  interpolate V3000 = "V3000"
 
 %runElab derive "MolVersion" [Eq,Ord,Show]
 


### PR DESCRIPTION
ChemAxon's tools don't want to parse `v2000` as the .mol-file version. In the specs, it looks rather like lower-case, but then, the specs are a bit crappy.