### PR TITLE
[ refactor ] be less restrictive when reading SD headers

### DIFF
--- a/src/Text/Molfile/SDF.idr
+++ b/src/Text/Molfile/SDF.idr
@@ -20,8 +20,14 @@ import Text.Molfile.Writer
 --------------------------------------------------------------------------------
 
 public export
+IsHeaderChar : Char -> Bool
+IsHeaderChar '>' = False
+IsHeaderChar '<' = False
+IsHeaderChar c   = not (isControl c) && c < '\128'
+
+public export
 0 IsHeader : String -> Type
-IsHeader = Len (<= 70) && Str (All $ AlphaNum || ('_' ===))
+IsHeader = Len (<= 70) && Str (All $ Holds IsHeaderChar)
 
 ||| Header of a SDF data entry. This is put in angles (`<>`) in an SD file.
 public export
@@ -152,7 +158,7 @@ header ('>'::xs) =
   case break ('<' ==) xs of
     (_, '<'::t) => readH [<] t
     _           => Left $ EInvalid $ pack xs
-header xs        = Left (EInvalid $ pack xs) 
+header xs        = Left (EInvalid $ pack xs)
 
 
 value : SDHeader -> SnocList String -> SDParser


### PR DESCRIPTION
These are dire times: No one cares about the SDF specs and I keep getting shitty SD files with invalid data headers from screening compound retailers. With this PR, we become less restrictive when parsing SD headers (but we won't create crappy headers ourselves).