### PR TITLE
[ new ] kekulize pi systems

### DIFF
--- a/app/src/Prog/Pretty.idr
+++ b/app/src/Prog/Pretty.idr
@@ -1,12 +1,24 @@
 module Prog.Pretty
 
+import Chem.Aromaticity
 import Prog.Util
 
 %default total
 
-act : List String -> SmilesGraph -> Prog ()
+Interpolation SmilesAtomAT where
+  interpolate a = a.type.name
+
+act : Interpolation e => Interpolation n => List String -> Graph e n -> Prog ()
 act [] (G _ g) = stdoutLn (pretty interpolate interpolate g)
 act _ _        = invalid
+
+kekulizeSmiles : SmilesGraph -> SmilesGraphAT
+kekulizeSmiles =
+  mapFst unarom . kekulize (const Dbl) . perceiveSmilesAtomTypes
+  where
+    unarom : SmilesBond -> SmilesBond
+    unarom Arom = Sngl
+    unarom b    = b
 
 export
 fromSmiles : String -> Prog SmilesGraph
@@ -14,5 +26,6 @@ fromSmiles = fromResult . readSmiles
 
 export
 prettySmiles : List String -> Prog ()
-prettySmiles (s::t) = fromSmiles s >>= act t
-prettySmiles []     = invalid
+prettySmiles ("kekulize"::s::t) = fromSmiles s >>= act t . kekulizeSmiles
+prettySmiles (s::t)             = fromSmiles s >>= act t
+prettySmiles []                 = invalid

--- a/pack.toml
+++ b/pack.toml
@@ -34,20 +34,8 @@ type   = "local"
 path   = "profile"
 ipkg   = "profile.ipkg"
 
-[custom.all.ref1]
+[custom.all.indexed-graph]
 type   = "git"
-url    = "https://github.com/stefan-hoeck/idris2-ref1"
+url    = "https://github.com/stefan-hoeck/idris2-indexed-graph"
 commit = "latest:main"
-ipkg   = "ref1.ipkg"
-
-[custom.all.ilex]
-type   = "git"
-url    = "https://github.com/stefan-hoeck/idris2-ilex"
-commit = "latest:main"
-ipkg   = "ilex.ipkg"
-
-[custom.all.ilex-core]
-type   = "git"
-url    = "https://github.com/stefan-hoeck/idris2-ilex"
-commit = "latest:main"
-ipkg   = "core/ilex-core.ipkg"
+ipkg   = "indexed-graph.ipkg"

--- a/src/Chem/Aromaticity.idr
+++ b/src/Chem/Aromaticity.idr
@@ -3,9 +3,11 @@ module Chem.Aromaticity
 import Chem.Atom
 import Chem.AtomType
 import Chem.Elem
+import Chem.Isotope
 import Chem.Rings.Relevant
 import Chem.Types
 import Data.Graph.Indexed
+import Data.Graph.Indexed.Util.Bipartite
 import Data.SortedMap
 import Data.SortedSet
 import Derive.Prelude
@@ -148,3 +150,26 @@ atMap =
 export
 atomType : Cast e Elem => Atom e Charge p r h AtomType c l -> Maybe Nat
 atomType a = lookup (cast a.elem, a.charge, a.type.hybridization) atMap
+
+--------------------------------------------------------------------------------
+-- Kekulization
+--------------------------------------------------------------------------------
+
+public export
+0 KAtom : (e,c,p,r,h,ch,l : Type) -> Type
+KAtom e c p r h ch l = Atom e c p r h AtomType ch l
+
+parameters {0 b,e,c,p,r,h,ch,l : Type}
+           {auto cb : Cast b BondOrder}
+           (setdbl  : b -> b)
+
+  available : IGraph k b (KAtom e c p r h ch l) -> Fin k -> Bool
+  available g x =
+   let A l es := adj g x
+    in S (count ((Dbl ==) . cast) es) == l.type.double
+
+  export
+  kekulize : Graph b (KAtom e c p r h ch l) -> Graph b (KAtom e c p r h ch l)
+  kekulize (G k g) =
+   let es := map setdbl <$> matchEdgesWhere g (available g)
+    in G k $ insEdges es g

--- a/test/src/Test/Chem/Aromaticity.idr
+++ b/test/src/Test/Chem/Aromaticity.idr
@@ -15,15 +15,26 @@ import Hedgehog
 toSB : AromBond SmilesBond -> SmilesBond
 toSB ab = if ab.arom then Arom else if ab.type == Arom then Sngl else ab.type
 
+to1 : SmilesBond -> SmilesBond
+to1 Arom = Sngl
+to1 b    = b
+
 readArom : String -> Either String (Graph SmilesBond SmilesAtomAT)
 readArom =
   map (mapFst toSB . aromatize atomType . perceiveSmilesAtomTypes) . readSmiles'
 
+readKekulee : String -> Either String (Graph SmilesBond SmilesAtomAT)
+readKekulee =
+  map (mapFst to1 . kekulize (const Dbl) . perceiveSmilesAtomTypes) . readSmiles'
+
 triples : Graph e n -> List (Nat,Nat,e)
-triples (G o g) = (\(E x y l) => (finToNat x, finToNat y, l)) <$> edges g 
+triples (G o g) = (\(E x y l) => (finToNat x, finToNat y, l)) <$> edges g
 
 testArom : String -> List (Nat,Nat,SmilesBond) -> Property
 testArom s ts = property1 $ map triples (readArom s) === Right ts
+
+testKekulize : String -> List (Nat,Nat,SmilesBond) -> Property
+testKekulize s ts = property1 $ map triples (readKekulee s) === Right ts
 
 --------------------------------------------------------------------------------
 -- One-cycle aromatic systems
@@ -152,6 +163,22 @@ prop_piperidine =
     [(0,1,Sngl),(0,5,Sngl),(1,2,Sngl),(2,3,Sngl),(3,4,Sngl),(4,5,Sngl)]
 
 --------------------------------------------------------------------------------
+-- Kekulization
+--------------------------------------------------------------------------------
+
+prop_kekulize_benzene : Property
+prop_kekulize_benzene =
+  testKekulize "c1ccccc1"
+    [(0,1,Dbl),(0,5,Sngl),(1,2,Sngl),(2,3,Dbl),(3,4,Sngl),(4,5,Dbl)]
+
+prop_kekulize_indole : Property
+prop_kekulize_indole =
+  testKekulize "c12ccccc1[nH]cc2"
+    [ (0,1,Dbl),(0,5,Sngl),(0,8,Sngl),(1,2,Sngl),(2,3,Dbl),(3,4,Sngl)
+    , (4,5,Dbl),(5,6,Sngl),(6,7,Sngl),(7,8,Dbl)
+    ]
+
+--------------------------------------------------------------------------------
 -- props
 --------------------------------------------------------------------------------
 
@@ -181,4 +208,7 @@ props =
 
     , ("prop_cyclohexane", prop_cyclohexane)
     , ("prop_piperidine", prop_piperidine)
+
+    , ("prop_kekulize_benzene", prop_kekulize_benzene)
+    , ("prop_kekulize_indole", prop_kekulize_indole)
     ]


### PR DESCRIPTION
This has been long overdue. If things go well, it will not only allow us to properly convert SMILES codes to .sd files but to also shift around double bonds when fusing rings in cyby-draw.

Currently, this will only work for bipartite graphs, but I expect the vast majority of pi systems to be of this type.